### PR TITLE
Add a command line at initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ requires the following to run:
 After `git clone`, run git submodule update command shown below.
 
 ```
+sudo apt install ros-kinetic-ros-control ros-kinetic-ros-controllers
 git submodule update --init
 ```
 


### PR DESCRIPTION
I found that the installation of ros-kinetic-ros-control and ros-kinetic-ros-controllers is required for catkin_make. 