### PR TITLE
Fixed bug

### DIFF
--- a/raspimouse_control/scripts/virtual_motors.py
+++ b/raspimouse_control/scripts/virtual_motors.py
@@ -16,34 +16,27 @@ def get_motor_freq():
             if motor_power_status=='0':
                 sound_count = 0
             if motor_power_status=='1' and sound_count == 0:
-                subprocess.call("aplay ~/catkin_ws/src/raspimouse_sim/raspimouse_control/scripts/ms_sound.wav", shell=True)
+                subprocess.call("aplay $(rospack find raspimouse_control)/scripts/ms_sound.wav", shell=True)
                 sound_count = 1
             if motor_power_status=='1':
                 with open(lfile,'r') as lf,\
                 open(rfile,'r') as rf:
                     lhz_str = lf.readline().rstrip()
                     rhz_str = rf.readline().rstrip()
-                if len(lhz_str)==0:
-                    print("Reset /dev/rtmotor_raw_l0")
-                    with open(lfile,'w') as lf:
-                        lf.write('0')
-                if len(rhz_str)==0:
-                    print("Reset /dev/rtmotor_raw_r0")
-                    with open(rfile,'w') as rf:
-                        rf.write('0')
-                else:
+                if len(rhz_str)!=0:
                     try:
                         lhz = int(lhz_str)
                     except:
                         lhz = 0
+                if len(lhz_str)!=0:
                     try:
                         rhz = int(rhz_str)
                     except:
                         rhz = 0
-                    vel.linear.x = (lhz+rhz)*9*math.pi/160000.0
-                    vel.angular.z = (rhz-lhz)*math.pi/800.0
-                    #print(vel)
-                    pub.publish(vel)
+                vel.linear.x = (lhz+rhz)*9*math.pi/160000.0
+                vel.angular.z = (rhz-lhz)*math.pi/800.0
+                print(vel)
+                pub.publish(vel)
 
         except rospy.ROSInterruptException:
             pass


### PR DESCRIPTION
デバイスファイルの読み取り時に整合性が取れない場合、欠落したデータをデバイスファイルに書き込み、補完する処理を行っていた。
しかし、補完の際に書き込み途中のデータを上書きしてしまい、正常な動作ができなくなる問題が発生していた。

正常な動作ができなくなる例:
![2018-04-20_21h42_15](https://user-images.githubusercontent.com/27679754/39051517-dd7e9dc6-44e3-11e8-8140-12eb09a32cdd.gif)
