### PR TITLE
Add use_devfile argumet to launch files to make virtual device file optional

### DIFF
--- a/raspimouse_control/launch/raspimouse_control.launch
+++ b/raspimouse_control/launch/raspimouse_control.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_devfile" default="true" />
+
   <!-- Load joint controller configurations from YAML file to parameter server -->
   <rosparam file="$(find raspimouse_control)/config/controller.yaml" command="load" />
 
@@ -17,8 +19,10 @@
       respawn="false" output="screen" />
     <!-- convert sensor values -->
     <!-- <node name="dev_file_generator" pkg="raspimouse_control" type="gen_dev_file.sh" /> -->
-    <node name="lightsensor_subscriber" pkg="raspimouse_control" type="virtual_led_sensors.py" />
-    <node name="stepper_cmd_vel_publisher" pkg="raspimouse_control" type="virtual_motors.py" />
+    <group if="$(arg use_devfile)">
+      <node name="lightsensor_subscriber" pkg="raspimouse_control" type="virtual_led_sensors.py" />
+      <node name="stepper_cmd_vel_publisher" pkg="raspimouse_control" type="virtual_motors.py" />
+    </group>
   </group>
 </launch>
 

--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_devfile" default="true" />
   <!-- these are the arguments you can pass this launch file, for example paused:=true -->
   <arg name="model" default="$(find raspimouse_description)/urdf/raspimouse.urdf.xacro"/>
   <arg name="paused" default="false"/>
@@ -18,11 +19,14 @@
   </include>
 
   <!-- Load the URDF into the ROS Parameter Server -->
-  <param name="raspimouse/robot_description" command="$(find xacro)/xacro.py '$(arg model)'" />
+
+  <param name="raspimouse_on_gazebo/robot_description" command="$(find xacro)/xacro '$(arg model)'" />
   
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
-  <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen" args="-urdf -model RasPiMouseV2 -param raspimouse/robot_description"/>
+  <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen" args="-urdf -model RasPiMouseV2 -param raspimouse_on_gazebo/robot_description"/>
 
   <!-- ros_control motoman launch file -->
-  <include file="$(find raspimouse_control)/launch/raspimouse_control.launch"/>
+  <include file="$(find raspimouse_control)/launch/raspimouse_control.launch">
+    <arg name="use_devfile" value="$(arg use_devfile)" />
+  </include>
 </launch>

--- a/raspimouse_gazebo/launch/raspimouse_with_gasstand.launch
+++ b/raspimouse_gazebo/launch/raspimouse_with_gasstand.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_devfile" default="true" />
   <!-- these are the arguments you can pass this launch file, for example paused:=true -->
   <arg name="model" default="$(find raspimouse_description)/urdf/raspimouse_urg.urdf.xacro"/>
   <arg name="paused" default="false"/>
@@ -25,5 +26,7 @@
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen" args="-urdf -model RaspberryPiMouseV2 -param raspimouse_on_gazebo/robot_description"/>
 
   <!-- ros_control motoman launch file -->
-  <include file="$(find raspimouse_control)/launch/raspimouse_control.launch"/>
+  <include file="$(find raspimouse_control)/launch/raspimouse_control.launch">
+    <arg name="use_devfile" value="$(arg use_devfile)" />
+  </include>
 </launch>

--- a/raspimouse_gazebo/launch/raspimouse_with_samplemaze.launch
+++ b/raspimouse_gazebo/launch/raspimouse_with_samplemaze.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_devfile" default="true" />
   <!-- these are the arguments you can pass this launch file, for example paused:=true -->
   <arg name="model" default="$(find raspimouse_description)/urdf/raspimouse.urdf.xacro"/>
   <arg name="paused" default="false"/>
@@ -25,5 +26,7 @@
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen" args="-urdf -model RaspberryPiMouseV2 -param raspimouse_on_gazebo/robot_description"/>
 
   <!-- ros_control motoman launch file -->
-  <include file="$(find raspimouse_control)/launch/raspimouse_control.launch"/>
+  <include file="$(find raspimouse_control)/launch/raspimouse_control.launch">
+    <arg name="use_devfile" value="$(arg use_devfile)" />
+  </include>
 </launch>


### PR DESCRIPTION
launchの引数でバーチャルデバイスファイルのON/OFFを切り替えられるようにしました。
#30 のための対応です。
デフォルトでuse_devfile:=trueにしていますが、falseにしても良いかもしれません。

~また、raspimouse_with_gasstand.launchが正常に起動しなかったので修正しています。~