### PR TITLE
Change default value of rtswitch0,1,2

### DIFF
--- a/raspimouse_control/scripts/gen_dev_file.sh
+++ b/raspimouse_control/scripts/gen_dev_file.sh
@@ -24,3 +24,7 @@ for targetfile in ${array[@]} ; do
 	sudo chmod 666 /dev/$targetfile
 	echo 0 > /dev/$targetfile
 done
+
+echo 1 > /dev/rtswitch0
+echo 1 > /dev/rtswitch1
+echo 1 > /dev/rtswitch2


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->

実機のRaspberryPiMouseでは、スイッチを押してない状態で/dev/rtswitch*が1になります。

実機に合わせるため、バーチャルファイルのrtswitch*のデフォルト値を1に変更します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

いいえ。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

Ubuntu 18.04で確認しました。