### PR TITLE
Update namespace to fix odom tf error

### DIFF
--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
@@ -10,6 +10,7 @@
   <arg name="use_devfile" default="false" />
   <arg name="world_name" default="$(find raspimouse_gazebo)/worlds/empty.world" />
   <arg name="xacro_option" default="lidar:=none" />
+  <arg name="robot_namespace" default="" />
   
   <!-- Initial position in Gazebo -->
   <arg name="x0" default="0"/>
@@ -26,12 +27,9 @@
     <arg name="headless" value="$(arg headless)" />
   </include>
 
-  <!-- Load the URDF into the ROS Parameter Server -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg model)' $(arg xacro_option)" />
-  
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
-    args="-urdf -model RasPiMouseV2 -param robot_description -x $(arg x0) -y $(arg y0) -z $(arg z0)"/>
+    args="-urdf -model RaspberryPiMouse -param robot_description -x $(arg x0) -y $(arg y0) -z $(arg z0)"/>
 
   <!-- Convert joint states to TF transforms for rviz, etc -->
   <!-- this requires joint_state_controller -->
@@ -41,11 +39,25 @@
   <group if="$(arg use_devfile)">
     <!-- Simulate device file -->
     <include file="$(find raspimouse_fake)/launch/virtual_device_file.launch" />
+    <!-- Load the URDF into the ROS Parameter Server -->
+    <param name="robot_description"
+      command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=false
+                robot_namespace:='$(arg robot_namespace)'
+                diffdrive_namespace:='/raspimouse_on_gazebo'
+                sensor_namespace:='raspimouse_on_gazebo'
+                $(arg xacro_option)" />
   </group>
   <group unless="$(arg use_devfile)">
     <!-- Simulate led distance sensor -->
     <node name="distance_sensor_simulator" pkg="raspimouse_gazebo" type="distance_sensor_simulator.py" />
-    <!-- Convert sensor values -->
-    <node name="cmd_vel_remapper" pkg="topic_tools" type="relay" args="cmd_vel raspimouse_on_gazebo/cmd_vel" />
+    <!-- Load the URDF into the ROS Parameter Server -->
+    <param name="robot_description"
+      command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=true diffdrive_namespace:='/' $(arg xacro_option)" />
+    <param name="robot_description"
+      command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=true
+                robot_namespace:='$(arg robot_namespace)'
+                diffdrive_namespace:='/'
+                sensor_namespace:='raspimouse_on_gazebo'
+                $(arg xacro_option)" />
   </group>
 </launch>

--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
@@ -52,8 +52,6 @@
     <node name="distance_sensor_simulator" pkg="raspimouse_gazebo" type="distance_sensor_simulator.py" />
     <!-- Load the URDF into the ROS Parameter Server -->
     <param name="robot_description"
-      command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=true diffdrive_namespace:='/' $(arg xacro_option)" />
-    <param name="robot_description"
       command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=true
                 robot_namespace:='$(arg robot_namespace)'
                 diffdrive_namespace:='/'

--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch
@@ -10,7 +10,7 @@
   <arg name="use_devfile" default="false" />
   <arg name="world_name" default="$(find raspimouse_gazebo)/worlds/empty.world" />
   <arg name="xacro_option" default="lidar:=none" />
-  <arg name="robot_namespace" default="" />
+  <arg name="robot_namespace" default="/" />
   
   <!-- Initial position in Gazebo -->
   <arg name="x0" default="0"/>
@@ -43,7 +43,7 @@
     <param name="robot_description"
       command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=false
                 robot_namespace:='$(arg robot_namespace)'
-                diffdrive_namespace:='/raspimouse_on_gazebo'
+                diffdrive_namespace:='$(arg robot_namespace)raspimouse_on_gazebo'
                 sensor_namespace:='raspimouse_on_gazebo'
                 $(arg xacro_option)" />
   </group>
@@ -54,7 +54,7 @@
     <param name="robot_description"
       command="$(find xacro)/xacro --inorder '$(arg model)' gazebo_plugin:=true tf:=true
                 robot_namespace:='$(arg robot_namespace)'
-                diffdrive_namespace:='/'
+                diffdrive_namespace:='$(arg robot_namespace)'
                 sensor_namespace:='raspimouse_on_gazebo'
                 $(arg xacro_option)" />
   </group>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

odom linkのネームスペースが異なるためtfでエラーが出る問題の修正です。

https://github.com/rt-net/raspimouse_description/pull/22 の変更が必須です。

`/odom` ではなく `/raspimouse_on_gazebo/odom` となってしまっていました。

before
![Screenshot from 2020-10-30 19-29-21](https://user-images.githubusercontent.com/3256629/97694784-6d17ab00-1ae6-11eb-9508-aa6dc4202dea.png)

after
![Screenshot from 2020-10-30 19-30-41](https://user-images.githubusercontent.com/3256629/97694797-7143c880-1ae6-11eb-8c90-5f8262b52bcf.png)


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
https://github.com/Tiryoh/docker-ros-desktop-vnc を用いて以下コマンドの通り実行して以下のリストの内容を確認しています。

```sh
# 1枚めの端末にて
mkdir -p ~/catkin_ws/src
cd ~/catkin_ws
catkin init
cd ~/catkin_ws/src
git clone https://github.com/ryuichiueda/raspimouse_ros_2.git
git clone https://github.com/rt-net/raspimouse_sim.git
git clone https://github.com/rt-net/raspimouse_description.git
(cd ~/catkin_ws/src/raspimouse_description  && git checkout fix/wheel-missing)
(cd ~/catkin_ws/src/raspimouse_sim  && git checkout fix/odom-tf)
rosdep install -r -y -i --from-paths raspimouse*
catkin build
catkin source
rosrun raspimouse_gazebo download_gazebo_models.sh
roslaunch raspimouse_gazebo raspimouse_with_samplemaze.launch
# 2枚めの端末にて
roslaunch raspimouse_gazebo  keyboard_teleop.launch
# 3枚めの端末にて
rosrun rqt_tf_tree rqt_tf_tree
```

* シミュレータが起動すること
*  `rqt_tf_tree`で`odom`から`base_footprint`へのtfが計算できていること


# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
