### PR TITLE
camera_downwardがtrueのときRGBカメラが斜め下を向くように変更

### DIFF
--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch.py
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch.py
@@ -46,6 +46,10 @@ def generate_launch_description():
         'use_rgb_camera',
         default_value='false',
         description='Set "true" to mount rgb camera.')
+    declare_arg_camera_downward = DeclareLaunchArgument(
+        'camera_downward',
+        default_value='false',
+        description='Set "true" to camera down.')
     declare_arg_world_name = DeclareLaunchArgument(
         'world_name',
         default_value=get_package_share_directory('raspimouse_gazebo')+'/worlds/empty_world.sdf',
@@ -94,6 +98,7 @@ def generate_launch_description():
     description_loader.lidar_frame = LaunchConfiguration('lidar_frame')
     description_loader.use_gazebo = 'true'
     description_loader.use_rgb_camera = LaunchConfiguration('use_rgb_camera')
+    description_loader.camera_downward = LaunchConfiguration('camera_downward')
     description_loader.gz_control_config_package = 'raspimouse_gazebo'
     description_loader.gz_control_config_file_path = 'config/raspimouse_controllers.yaml'
 
@@ -154,6 +159,7 @@ def generate_launch_description():
         declare_arg_lidar,
         declare_arg_lidar_frame,
         declare_arg_use_rgb_camera,
+        declare_arg_camera_downward,
         declare_arg_world_name,
         declare_arg_spawn_x,
         declare_arg_spawn_y,

--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch.py
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
     declare_arg_camera_downward = DeclareLaunchArgument(
         'camera_downward',
         default_value='false',
-        description='Set "true" to camera down.')
+        description='Set "true" to point the camera downwards.')
     declare_arg_world_name = DeclareLaunchArgument(
         'world_name',
         default_value=get_package_share_directory('raspimouse_gazebo')+'/worlds/empty_world.sdf',


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
camera_downwardをtrueにすると、RGBカメラのモデルが斜め30度下を向き、画像トピックの姿勢も同じように斜め30度下を向きます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記のコマンドを実行すると、Gazebo上でRGBカメラが斜め30度下を向いていることを確認できます。また、RViz上では画像トピックの姿勢が斜め30度下を向いていることも確認できます。

https://github.com/rt-net/raspimouse_description/pull/50 が必要です。

```sh
ros2 launch raspimouse_gazebo raspimouse_with_line_follower_field.launch.py use_rgb_camera:=true camera_downward:=true
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
