### PR TITLE
シミュレータ環境でSLAMとNavigationを実行

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -93,6 +93,71 @@ ros2 launch raspimouse_ros2_examples object_tracking.launch.py mouse:=false use_
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_object_tracking.gif)
 
+### camera_line_follower 
+
+Terminal 1:
+
+```sh
+ros2 launch raspimouse_gazebo raspimouse_with_line_follower_field.launch.py use_rgb_camera:=true camera_downward:=true
+```
+
+Terminal 2:
+
+```sh
+ros2 launch raspimouse_ros2_examples camera_line_follower.launch.py mouse:=false use_camera_node:=false
+```
+
+Terminal 3: Start
+
+```sh
+ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: false, switch1: false, switch2: true}"
+```
+
+Terminal 3: Stop
+```sh
+ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: true, switch1: false, switch2: false}"
+```
+
+For information on parameters in camera line follower, click [here](https://github.com/rt-net/raspimouse_ros2_examples/blob/master/README.en.md#parameters).
+
+### SLAM & Navigation
+
+#### SLAM
+
+Terminal 1:
+```sh
+ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
+```
+The lidar option supports `urg`, `lds`, and `rplidar`.
+
+Terminal 2:
+```sh
+ros2 launch raspimouse_ros2_examples teleop_joy.launch.py joydev:="/dev/input/js0" joyconfig:=f710 mouse:=false
+```
+
+Terminal 3:
+```sh
+ros2 launch raspimouse_slam pc_slam.launch.py
+```
+
+Terminal 4:
+```sh
+ros2 run nav2_map_server map_saver_cli -f ~/MAP_NAME
+```
+
+#### Navigation
+
+Terminal 1:
+```sh
+ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
+```
+The lidar option supports `urg`, `lds`, and `rplidar`.
+
+Terminal 2:
+```sh
+ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME.yaml
+```
+
 ## Model data list
 
 ### course_curve_50x50cm
@@ -113,7 +178,7 @@ The cube colors are red, yellow, blue, and green.
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/color_objects.png)
 
-### daeファイルについて
+### about dae files
 The dae file is edited in Blender 4.0.
 
 ## License

--- a/README.en.md
+++ b/README.en.md
@@ -120,6 +120,8 @@ ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: true, sw
 
 For information on parameters in camera line follower, click [here](https://github.com/rt-net/raspimouse_ros2_examples/blob/master/README.en.md#parameters).
 
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_camerafollower_short.gif)
+
 ### SLAM & Navigation
 
 #### SLAM
@@ -140,10 +142,14 @@ Terminal 3:
 ros2 launch raspimouse_slam pc_slam.launch.py
 ```
 
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_slam.png)
+
 Terminal 4:
 ```sh
 ros2 run nav2_map_server map_saver_cli -f ~/MAP_NAME
 ```
+
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_slam_short.gif)
 
 #### Navigation
 
@@ -157,6 +163,8 @@ Terminal 2:
 ```sh
 ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME.yaml
 ```
+
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_navigation_short.gif)
 
 ## Model data list
 
@@ -173,8 +181,8 @@ Panel size is 50 cm x 50 cm and line width is 4 cm.
 ![](./raspimouse_gazebo/models/course_straight_50x50cm/meshes/course_straight.jpg)
 
 ### cube_*cm_color-name
-Each cube is 5 cm, 7.5 cm, 10 cm, and 15 cm on a side.
-The cube colors are red, yellow, blue, and green.
+Each cube is 5 cm, 7.5 cm, 10 cm, and 15 cm, 30 cm on a side.
+The cube colors are red, yellow, blue, green and black.
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/color_objects.png)
 

--- a/README.en.md
+++ b/README.en.md
@@ -161,7 +161,7 @@ The lidar option supports `urg`, `lds`, and `rplidar`.
 
 Terminal 2:
 ```sh
-ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME.yaml
+ros2 launch raspimouse_navigation pc_navigation.launch.py map:=$HOME/MAP_NAME.yaml
 ```
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_navigation_short.gif)

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
 
 端末2で次のコマンドを実行すると、Navigationが実行されます。
 ```sh
-ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME.yaml
+ros2 launch raspimouse_navigation pc_navigation.launch.py map:=$HOME/MAP_NAME.yaml
 ```
 `map:=/path/to/MAP_NAME.yaml`はSLAMで作成した地図ファイルのパスを指定してください。
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
 ```sh
 ros2 launch raspimouse_navigation pc_navigation.launch.py map:=$HOME/MAP_NAME.yaml
 ```
-`map:=/path/to/MAP_NAME.yaml`はSLAMで作成した地図ファイルのパスを指定してください。
+引数`map`にはSLAMで作成した地図ファイルのパスを指定してください。
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_navigation_short.gif)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ git clone -b ros2 https://github.com/rt-net/raspimouse_sim.git
 ```sh
 cd ~/ros2_ws/src
 git clone https://github.com/rt-net/raspimouse_ros2_examples.git
+git clone https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
 git clone -b ros2 https://github.com/rt-net/raspimouse_description.git
 rosdep install -r -y -i --from-paths raspimouse*
 ```
@@ -92,6 +93,70 @@ ros2 launch raspimouse_ros2_examples object_tracking.launch.py mouse:=false use_
 ```
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_object_tracking.gif)
+
+### RGBカメラを用いたライントレースサンプル
+
+端末1で次のコマンドを実行すると、ライントレースのサンプルコースが配置されたワールドが表示されます。
+```sh
+ros2 launch raspimouse_gazebo raspimouse_with_line_follower_field.launch.py use_rgb_camera:=true camera_downward:=true
+```
+
+端末2で次のコマンドを実行すると、カメラライントレースのノードが起動します。
+```sh
+ros2 launch raspimouse_ros2_examples camera_line_follower.launch.py mouse:=false use_camera_node:=false
+```
+
+端末3で次のコマンドを実行すると、Raspberry Pi Mouseが走行を開始します。
+```sh
+ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: false, switch1: false, switch2: true}"
+```
+
+次のコマンドを実行すると、Raspberry Pi Mouseが停止します。
+```sh
+ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: true, switch1: false, switch2: false}"
+```
+
+カメラライントレースにおけるパラメータは[こちら](https://github.com/rt-net/raspimouse_ros2_examples?tab=readme-ov-file#parameters)を参照してください。
+
+### LiDARを用いたSLAMとNavigationのサンプル
+
+#### SLAM
+
+端末1で次のコマンドを実行すると、`Lake House`のモデルが配置されたワールドが表示されます。
+```sh
+ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
+```
+`lidar`は`urg`、`lds`、`rplidar`のいずれかを指定してください。
+
+端末2で次のコマンドを実行すると、Raspberry Pi Mouseをジョイスティックコントローラで操作できます。
+```sh
+ros2 launch raspimouse_ros2_examples teleop_joy.launch.py joydev:="/dev/input/js0" joyconfig:=f710 mouse:=false
+```
+
+端末3で次のコマンドを実行すると、SLAMが実行されます。
+```sh
+ros2 launch raspimouse_slam pc_slam.launch.py
+```
+
+端末4で次のコマンドを実行すると、作成した地図を保存できます。
+```sh
+ros2 run nav2_map_server map_saver_cli -f ~/MAP_NAME
+```
+`MAP_NAME`は任意の名前を指定できます。
+
+#### Navigation
+
+端末1で次のコマンドを実行すると、`Lake House`のモデルが配置されたワールドが表示されます。
+```sh
+ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
+```
+`lidar`は`urg`、`lds`、`rplidar`のいずれかを指定してください。
+
+端末2で次のコマンドを実行すると、Navigationが実行されます。
+```sh
+ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME.yaml
+```
+`map:=/path/to/MAP_NAME.yaml`はSLAMで作成した地図ファイルのパスを指定してください。
 
 ## モデルデータ一覧
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: true, sw
 
 カメラライントレースにおけるパラメータは[こちら](https://github.com/rt-net/raspimouse_ros2_examples?tab=readme-ov-file#parameters)を参照してください。
 
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_camerafollower_short.gif)
+
 ### LiDARを用いたSLAMとNavigationのサンプル
 
 #### SLAM
@@ -138,11 +140,15 @@ ros2 launch raspimouse_ros2_examples teleop_joy.launch.py joydev:="/dev/input/js
 ros2 launch raspimouse_slam pc_slam.launch.py
 ```
 
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_slam.png)
+
 端末4で次のコマンドを実行すると、作成した地図を保存できます。
 ```sh
 ros2 run nav2_map_server map_saver_cli -f ~/MAP_NAME
 ```
 `MAP_NAME`は任意の名前を指定できます。
+
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_slam_short.gif)
 
 #### Navigation
 
@@ -157,6 +163,8 @@ ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
 ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME.yaml
 ```
 `map:=/path/to/MAP_NAME.yaml`はSLAMで作成した地図ファイルのパスを指定してください。
+
+![](https://rt-net.github.io/images/raspberry-pi-mouse/raspimouse_sim_navigation_short.gif)
 
 ## モデルデータ一覧
 
@@ -175,8 +183,8 @@ ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/path/to/MAP_NAME
 ![](./raspimouse_gazebo/models/course_straight_50x50cm/meshes/course_straight.jpg)
 
 ### cube_*cm_color-name
-それぞれ一辺5cm、7.5cm、10cm、15cmの立方体です。
-色は赤、黄、青、緑です。
+それぞれ一辺5cm、7.5cm、10cm、15cm、30cmの立方体です。
+色は赤、黄、青、緑、黒です。
 
 ![](https://rt-net.github.io/images/raspberry-pi-mouse/color_objects.png)
 

--- a/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch.py
+++ b/raspimouse_gazebo/launch/raspimouse_with_emptyworld.launch.py
@@ -135,6 +135,7 @@ def generate_launch_description():
         package='ros_gz_bridge',
         executable='parameter_bridge',
         arguments=['/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock',
+                   '/scan@sensor_msgs/msg/LaserScan@ignition.msgs.LaserScan',
                    '/camera/color/image_raw@sensor_msgs/msg/Image@gz.msgs.Image',
                    '/camera_info@sensor_msgs/msg/CameraInfo@gz.msgs.CameraInfo'],
         output='screen'

--- a/raspimouse_gazebo/launch/raspimouse_with_lakehouse.launch.py
+++ b/raspimouse_gazebo/launch/raspimouse_with_lakehouse.launch.py
@@ -1,0 +1,48 @@
+# The MIT License (MIT)
+#
+# Copyright 2023 RT Corporation <support@rt-net.jp>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch_ros.actions import SetParameter
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+
+def generate_launch_description():
+    world_file = os.path.join(
+        get_package_share_directory('raspimouse_gazebo'),
+        'worlds',
+        'lakehouse.sdf')
+    world_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([
+            get_package_share_directory('raspimouse_gazebo'),
+            '/launch/raspimouse_with_emptyworld.launch.py']),
+        launch_arguments={
+            'world_name': world_file
+            }.items()
+    )
+
+    return LaunchDescription([
+        SetParameter(name='use_sim_time', value=True),
+        world_launch
+    ])

--- a/raspimouse_gazebo/launch/raspimouse_with_lakehouse.launch.py
+++ b/raspimouse_gazebo/launch/raspimouse_with_lakehouse.launch.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright 2023 RT Corporation <support@rt-net.jp>
+# Copyright 2024 RT Corporation <support@rt-net.jp>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/raspimouse_gazebo/models/cube_30cm_black/model.config
+++ b/raspimouse_gazebo/models/cube_30cm_black/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<model>
+  <name>Black Cube 30cm</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>YusukeKato</name>
+    <email>yusuke.kato@rt-net.jp</email>
+  </author>
+
+  <description>
+    Cube
+  </description>
+</model>

--- a/raspimouse_gazebo/models/cube_30cm_black/model.sdf
+++ b/raspimouse_gazebo/models/cube_30cm_black/model.sdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+    <model name="cube_30cm_black">
+      <link name="cube_black_link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="cube_black_collision">
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="cube_black_visual">
+          <material>
+            <ambient>0 0 0 1</ambient>
+            <diffuse>0 0 0 1</diffuse>
+            <specular>0 0 0 0</specular>
+            <emissive>0 0 0 1</emissive>
+          </material>
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.3</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+</sdf>

--- a/raspimouse_gazebo/package.xml
+++ b/raspimouse_gazebo/package.xml
@@ -20,6 +20,8 @@
   <depend>raspimouse_fake</depend>
   <depend>raspimouse_description</depend>
   <depend>robot_state_publisher</depend>
+  <depend>diff_drive_controller</depend>
+  <depend>joint_state_broadcaster</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspimouse_gazebo/worlds/lakehouse.sdf
+++ b/raspimouse_gazebo/worlds/lakehouse.sdf
@@ -42,5 +42,47 @@
       </uri>
     </include>
 
+    <model name="black_cube11">
+      <include>
+        <uri>model://cube_30cm_black</uri>
+      </include>
+      <pose>-0.5 0 0.075 0 0 0</pose>
+    </model>
+
+    <model name="black_cube12">
+      <include>
+        <uri>model://cube_30cm_black</uri>
+      </include>
+      <pose>-0.5 1.0 0.075 0 0 0</pose>
+    </model>
+
+    <model name="black_cube13">
+      <include>
+        <uri>model://cube_30cm_black</uri>
+      </include>
+      <pose>-0.5 -1.0 0.075 0 0 0</pose>
+    </model>
+
+    <model name="black_cube21">
+      <include>
+        <uri>model://cube_30cm_black</uri>
+      </include>
+      <pose>2.0 0 0.075 0 0 0</pose>
+    </model>
+
+    <model name="black_cube22">
+      <include>
+        <uri>model://cube_30cm_black</uri>
+      </include>
+      <pose>2.0 1.0 0.075 0 0 0</pose>
+    </model>
+
+    <model name="black_cube23">
+      <include>
+        <uri>model://cube_30cm_black</uri>
+      </include>
+      <pose>2.0 -1.0 0.075 0 0 0</pose>
+    </model>
+
   </world>
 </sdf>

--- a/raspimouse_gazebo/worlds/lakehouse.sdf
+++ b/raspimouse_gazebo/worlds/lakehouse.sdf
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <include>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Sun
+      </uri>
+    </include>
+
+    <include>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ground%20Plane
+      </uri>
+    </include>
+
+    <include>
+      <pose>0 0 -7.0 0 0 0</pose>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Lake%20House
+      </uri>
+    </include>
+
+  </world>
+</sdf>

--- a/raspimouse_gazebo/worlds/lakehouse.sdf
+++ b/raspimouse_gazebo/worlds/lakehouse.sdf
@@ -10,6 +10,11 @@
       name="ignition::gazebo::systems::Physics">
     </plugin>
     <plugin
+      filename="ignition-gazebo-sensors-system"
+      name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin
       filename="ignition-gazebo-user-commands-system"
       name="ignition::gazebo::systems::UserCommands">
     </plugin>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
Gazebo上でSLAMとNavigationを実行できるように変更します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

## SLAMの動作確認

lidarは"urg"、"lds"、"rplidar"のうちいずれかを指定
```sh
ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
```

ジョイスティックコントローラで操作
```sh
ros2 launch raspimouse_ros2_examples teleop_joy.launch.py joydev:="/dev/input/js0" joyconfig:=f710 mouse:=false
```

SLAMを実行
```sh
ros2 launch raspimouse_slam pc_slam.launch.py
```

十分走らせて地図を作成したら、次のコマンドで地図を保存
```sh
ros2 run nav2_map_server map_saver_cli -f ~/MAP_NAME
```

## Navigationの動作確認

lidarは"urg"、"lds"、"rplidar"のうちいずれかを指定
```sh
ros2 launch raspimouse_gazebo raspimouse_with_lakehouse.launch.py lidar:=urg
```

ナビゲーションを実行（マップのパスを指定）
```sh
ros2 launch raspimouse_navigation pc_navigation.launch.py map:=/home/ubuntu/MAP_NAME.yaml
```

# Any other comments?
<!-- その他コメントはありますか？ -->
raspimouse_descriptionパッケージのadd-slam-navigationブランチが必要です。

https://github.com/rt-net/raspimouse_description/pull/52

raspimouse_slam_navigation_ros2パッケージも必要です。

https://github.com/rt-net/raspimouse_slam_navigation_ros2

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
